### PR TITLE
Corrected URL of bit.ly

### DIFF
--- a/views/pages/index.hbs
+++ b/views/pages/index.hbs
@@ -19,7 +19,7 @@
   </p>
   <p>
     With <a href="https://goo.gl">goo.gl</a> having shut down and most unique single word
-    links at <a href="https://bit.ly">bit.ly</a> having run out, we have made <b><u>cb.lk</u></b>
+    links at <a href="https://bitly.com">bit.ly</a> having run out, we have made <b><u>cb.lk</u></b>
     open for anyone to use. Only one catch - you need to login using a Coding Blocks account.
   </p>
   <a class="btn btn-outline-primary btn-lg mx-4 my-1" href="https://codingblocks.com" role="button">


### PR DESCRIPTION
Minor Change:
**bit.ly** changed name to **bitly** and hence their domain name changed from **bit.ly** to **bitly.com**. I am submitting a PR to correct the link on the main page.